### PR TITLE
Add SIGINT handler for graceful shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,3 +22,8 @@ api.get('/', (req, res) => {
 
 api.listen(PORT, HOST)
 console.log(`Running on http://${HOST}:${PORT}`)
+
+// Handle SIGINT (Ctrl+C)
+process.on('SIGINT', () => {
+  process.exit(0);
+})


### PR DESCRIPTION
This pull request adds a handler for the `SIGINT` signal to ensure the application exits gracefully when interrupted pressing `Ctrl+C`.